### PR TITLE
fix: branchws stays in new workspace folder after creation

### DIFF
--- a/src/andrei/copilot.ps1
+++ b/src/andrei/copilot.ps1
@@ -220,31 +220,32 @@ function New-BranchWorkspace {
 		return
 	}
 
-	Push-Location $targetFolder
-
-	try {
-		# Check whether the branch already exists on the remote
-		$remoteBranch = git ls-remote --heads origin $BranchName 2>$null
-		if ($remoteBranch) {
-			Write-Host "Branch '$BranchName' exists on remote. Checking out..." -ForegroundColor Green
-			git checkout $BranchName
-		}
-		else {
-			Write-Host "Branch '$BranchName' does not exist. Creating..." -ForegroundColor Yellow
-			git checkout -b $BranchName
-		}
-
-		Write-Host ""
-		Write-Host "sbx run copilot"
+	# Check whether the branch already exists on the remote
+	$remoteBranch = git -C $targetFolder ls-remote --heads origin $BranchName 2>$null
+	if ($remoteBranch) {
+		Write-Host "Branch '$BranchName' exists on remote. Checking out..." -ForegroundColor Green
+		git -C $targetFolder checkout $BranchName
 	}
-	finally {
-		Pop-Location
+	else {
+		Write-Host "Branch '$BranchName' does not exist. Creating..." -ForegroundColor Yellow
+		git -C $targetFolder checkout -b $BranchName
 	}
+
+	Write-Host "Launching github desktop in the new workspace..." -ForegroundColor Cyan
+	Start-Process "github" -ArgumentList ".", $targetFolder
+	Write-Host "tmux -s $BranchName" -ForegroundColor Cyan
+	Write-Host "sbx run copilot"
+
+	Set-Location $targetFolder
+
 }
 
 Set-Alias -Name branchws -Value New-BranchWorkspace
 
 #usage New-BranchWorkspace myFeature
 #usage branchws myFeature
+
+
+
 
 


### PR DESCRIPTION
Replace Push-Location/Pop-Location pattern with git -C $targetFolder for git commands and Set-Location at the end, so the shell remains in the newly created workspace after the function completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub Desktop now launches automatically when creating a new branch workspace.
  * Added tmux session command output for workspace management.

* **Refactor**
  * Simplified branch workspace creation workflow with improved directory targeting and streamlined initialization sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->