### PR TITLE
fix: launch GitHub Desktop in the new workspace folder

### DIFF
--- a/src/andrei/copilot.ps1
+++ b/src/andrei/copilot.ps1
@@ -232,8 +232,8 @@ function New-BranchWorkspace {
 	}
 
 	Write-Host "Launching github desktop in the new workspace..." -ForegroundColor Cyan
-	Start-Process "github" -ArgumentList ".", $targetFolder
-	Write-Host "tmux -s $BranchName" -ForegroundColor Cyan
+	Start-Process "github" -ArgumentList $targetFolder
+	Write-Host "tmux new -s $BranchName" -ForegroundColor Cyan
 	Write-Host "sbx run copilot"
 
 	Set-Location $targetFolder
@@ -244,6 +244,9 @@ Set-Alias -Name branchws -Value New-BranchWorkspace
 
 #usage New-BranchWorkspace myFeature
 #usage branchws myFeature
+
+
+
 
 
 


### PR DESCRIPTION
Pass $targetFolder directly to Start-Process instead of '.' so GitHub Desktop opens the newly created branch workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified GitHub Desktop launch parameters for improved reliability.

* **Style**
  * Clarified tmux session creation command in help messaging.
  * Improved code formatting with additional spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->